### PR TITLE
Fixes  deprecations which are now errors in Python 3.10

### DIFF
--- a/pyactr/buffers.py
+++ b/pyactr/buffers.py
@@ -3,11 +3,12 @@ General class on buffers.
 """
 
 import collections
+from collections.abc import MutableSet
 
 import pyactr.chunks as chunks
 import pyactr.utilities as utilities
 
-class Buffer(collections.MutableSet):
+class Buffer(MutableSet):
     """
     Buffer module.
     """

--- a/pyactr/chunks.py
+++ b/pyactr/chunks.py
@@ -3,6 +3,7 @@ Chunks
 """
 
 import collections
+from collections.abc import Sequence
 import re
 import warnings
 
@@ -35,7 +36,7 @@ def chunktype(cls_name, field_names, defaults=None):
     except TypeError:
         Chunk._chunktypes.update({cls_name:collections.namedtuple(cls_name, field_names)}) #chunktypes are not returned; they are stored as Chunk class attribute
 
-class Chunk(collections.Sequence):
+class Chunk(Sequence):
     """
     ACT-R chunks. Based on namedtuple (tuple with dictionary-like properties).
 

--- a/pyactr/declarative.py
+++ b/pyactr/declarative.py
@@ -3,6 +3,7 @@ Declarative memory. Consists of the actual declarative memory, and its associate
 """
 
 import collections
+from collections.abc import MutableMapping
 import math
 
 import numpy as np
@@ -11,7 +12,7 @@ import pyactr.chunks as chunks
 import pyactr.utilities as utilities
 import pyactr.buffers as buffers
 
-class DecMem(collections.MutableMapping):
+class DecMem(MutableMapping):
     """
     Declarative memory module.
     """


### PR DESCRIPTION
After these changes, `tests/tests.py` runs cleanly with Python 3.10