### PR TITLE
change collections to collections.abc

### DIFF
--- a/pyactr/environment.py
+++ b/pyactr/environment.py
@@ -49,7 +49,7 @@ class Environment(object):
 
     @current_focus.setter
     def current_focus(self, value):
-        if isinstance(value, collections.Iterable) and len(value) == 2:
+        if isinstance(value, collections.abc.Iterable) and len(value) == 2:
             self.__current_focus = list(value)
         else:
             raise ValueError('Current focus in the environment not defined properly. It must be a tuple.')
@@ -75,18 +75,18 @@ class Environment(object):
         #subtract start_time from initial_time
         start_time = self.initial_time - start_time
         #make all arguments iterables if they are not yet
-        if isinstance(stimuli, str) or isinstance(stimuli, collections.Mapping) or not isinstance(stimuli, collections.Iterable):
+        if isinstance(stimuli, str) or isinstance(stimuli, collections.abc.Mapping) or not isinstance(stimuli, collections.abc.Iterable):
             stimuli = [stimuli]
         for idx in range(len(stimuli)):
-            if isinstance(stimuli[idx], collections.Mapping):
+            if isinstance(stimuli[idx], collections.abc.Mapping):
                 for each in stimuli[idx]:
-                    if not isinstance(stimuli[idx][each], collections.Mapping): #stimuli[idx][each] encodes position etc.
+                    if not isinstance(stimuli[idx][each], collections.abc.Mapping): #stimuli[idx][each] encodes position etc.
                         raise utilities.ACTRError("Stimuli must be a list of dictionaries, e.g.,: [{'stimulus1-0time': {'text': 'hi', 'position': (0, 0)}, 'stimulus2-0time': {'text': 'you', 'position': (10, 10)}}, {'stimulus3-latertime': {'text': 'new', 'position': (0, 0)}}] etc. Currently, you have this: '%s'" %stimuli[idx])
             else:
                 stimuli[idx] = {stimuli[idx]: {'position': (320, 180)}} #default position - 320, 180
-        if isinstance(triggers, str) or not isinstance(triggers, collections.Iterable):
+        if isinstance(triggers, str) or not isinstance(triggers, collections.abc.Iterable):
             triggers = [triggers]
-        if isinstance(times, str) or not isinstance(times, collections.Iterable):
+        if isinstance(times, str) or not isinstance(times, collections.abc.Iterable):
             times = [times]
         #sanity checks - each arg must match in length, or an argument must be of length 1 (2 for positions)
         if len(stimuli) != len(triggers):


### PR DESCRIPTION
Aliases to Iterable and Mapping from collections were [removed in 3.10](https://docs.python.org/3.9/library/collections.html). Now they have to be imported from collections.abc