### PR TITLE
Fix baselevel_learning function for hard-coded activations & when bll is off

### DIFF
--- a/pyactr/utilities.py
+++ b/pyactr/utilities.py
@@ -425,32 +425,33 @@ def baselevel_learning(current_time, times, bll, decay, activation=None, optimiz
     """
     Calculate base-level learning: B_i = ln(sum(t_j^{-decay})) for t_j = current_time - t for t in times.
     """
-    if len(times) > 0:
-        with warnings.catch_warnings(record=True):
-            warnings.filterwarnings('error')
-            if bll and not optimized_learning:
-                try:
-                    B = math.log(np.sum((current_time - times) ** (-decay)))
-                #this part removes chunk storages that are stored at current time (blocking simultaneous retrieval)
-                except RuntimeWarning:
-                    temp_times = np.delete(times, times.argmax())
-                    if len(temp_times) > 0:
-                        B = math.log(np.sum((current_time - temp_times) ** (-decay)))
-            elif bll:
-                try:
-                    B = math.log(len(times)/(1-decay)) - decay*math.log(current_time - np.max(times)) #calculating bll using optimized learning -- much faster since it's a single calculation
-                #this part removes chunk storages that are stored at current time (blocking simultaneous retrieval)
-                except RuntimeWarning:
-                    temp_times = np.delete(times, times.argmax())
-                    if len(temp_times) > 0:
-                        B = math.log(len(times)/(1-decay)) - decay*math.log(current_time - np.max(temp_times)) #calculating bll using optimized learning -- much faster since it's a single calculation
-
-    #add hard-coded activation
-    if activation != None:
-        try:
-            B = math.log(math.exp(B) + math.exp(activation))
-        except NameError:
+    if bll:
+        if len(times) > 0:
+            with warnings.catch_warnings(record=True):
+                warnings.filterwarnings('error')
+                if not optimized_learning:
+                    try:
+                        B = math.log(np.sum((current_time - times) ** (-decay)))
+                    #this part removes chunk storages that are stored at current time (blocking simultaneous retrieval)
+                    except RuntimeWarning:
+                        temp_times = np.delete(times, times.argmax())
+                        if len(temp_times) > 0:
+                            B = math.log(np.sum((current_time - temp_times) ** (-decay)))
+                else:
+                    try:
+                        B = math.log(len(times)/(1-decay)) - decay*math.log(current_time - np.max(times)) #calculating bll using optimized learning -- much faster since it's a single calculation
+                    #this part removes chunk storages that are stored at current time (blocking simultaneous retrieval)
+                    except RuntimeWarning:
+                        temp_times = np.delete(times, times.argmax())
+                        if len(temp_times) > 0:
+                            B = math.log(len(times)/(1-decay)) - decay*math.log(current_time - np.max(temp_times)) #calculating bll using optimized learning -- much faster since it's a single calculation
+    else:
+        if activation:
+            #add hard-coded activation
             B = activation
+        else:
+            B = 0
+
     return B
 
 def calculate_instantaneous_noise(instantaneous_noise):
@@ -707,4 +708,3 @@ def splitting_submodules(string): #currently not used, maybe eventually !!!not u
     variables = re.findall("(?<="+ ACTRVARIABLER+").*?(?=$)", string)
     retrievals = re.findall("(?<="+ ACTRRETRIEVER+").*?(?=$)", string)
     return {"variables": set(variables), "retrievals": set(retrievals)}
-


### PR DESCRIPTION
**Note:** Based on reading the code, this PR assumes that pyactr's DecMem `add_activation` is supposed to be equivalent to `set-base-levels`.

I couldn't find any documentation of `add_activation` (other than "Add activation of an element." 😄 ), but it looks like it's supposed to be equivalent based on the `#add hard-coded activation` comment.

**Edit:** This change also fixes #23

## Details
In ACT-R, you can explicitly set base-level activations for a chunk:

```lisp
(define-model test-base-levels
       (sgp :esc t :bll nil)
       (add-dm (a isa chunk)
               (b isa chunk)
               (c isa chunk)))

(set-base-levels (c 10))
```

This will set c's base level to 10.

Looking at the code for `baselevel_learning` in utilities, this is at the end:

```python
    #add hard-coded activation
    if activation != None:
        try:
            B = math.log(math.exp(B) + math.exp(activation))
        except NameError:
            B = activation
```

From reading the math in the manual (pg. 291), it looks like `activation` should only be used when `baselevel_learning` (:bll) is off, and it's a straight assignment:

> If :bll is **nil** then the setting of :ol does not matter and the base-level is a constant value determined by the :blc parameter or specific user settings for the chunk.
$$B_i = β_i$$
$`β_i`$: A constant offset which is determined by the :blc parameter or the chunk’s :base-level parameter.

(Note: it doesn't look like ACT-R's `:blc` (base-level constant) parameter is available in pyactr; this would be added to the `B` calculations when `bll` is active, or used in the above assignment if no base level activation is hard-coded. It defaults to 0.0 (pg. 298).)
