### PR TITLE
Complex visual objects

### DIFF
--- a/pyactr/chunks.py
+++ b/pyactr/chunks.py
@@ -18,7 +18,7 @@ def chunktype(cls_name, field_names, include=None, defaults=None):
     >>> chunktype('chunktype_example0', 'value')
 
     :param field_names: an iterable or a string of slot names separated by spaces
-    :param include: a string naming an existing chunk type to inherit slot names from
+    :param include: a string or list of strings naming existing chunk type(s) to inherit slot names from
     :param defaults: default values for the slots, given as an iterable, counting from the last element
     """
     if cls_name in utilities.SPECIALCHUNKTYPES and field_names != utilities.SPECIALCHUNKTYPES[cls_name]:
@@ -35,12 +35,16 @@ def chunktype(cls_name, field_names, include=None, defaults=None):
 
     # If an ancestor was specified, union the field names and re-sort
     if include:
-        try:
-            inherits = Chunk._chunktypes[include]._fields
+        inherits = []
+        if isinstance(include, str):
+            include = [include]
+        for parent_name in include:
+            try:
+                inherits += Chunk._chunktypes[parent_name]._fields
+            except KeyError:
+                raise ACTRError("The parent chunk type '%s' was not found" % parent_name)
             unique_field_names = set(field_names).union(set(inherits))
             field_names = tuple(sorted(list(unique_field_names)))
-        except KeyError:
-            raise ACTRError("The parent chunk type '%s' was not found" % include)
 
     try:
         Chunk._chunktypes.update({cls_name:collections.namedtuple(cls_name, field_names, defaults=defaults)}) #chunktypes are not returned; they are stored as Chunk class attribute

--- a/pyactr/chunks.py
+++ b/pyactr/chunks.py
@@ -10,7 +10,7 @@ import warnings
 import pyactr.utilities as utilities
 from pyactr.utilities import ACTRError
 
-def chunktype(cls_name, field_names, include=None, defaults=None):
+def chunktype(cls_name, field_names, defaults=None, include=None):
     """
     Creates type chunk. Works like namedtuple.
 

--- a/pyactr/environment.py
+++ b/pyactr/environment.py
@@ -71,6 +71,10 @@ class Environment(object):
         start_time: starting point of the first stimulus.
 
         The length of triggers has to match the length of stimuli or one of them has to be of length 1.
+
+        Arbitrary visual attributes can be added as keys within each stimulus dictionary
+        You must also specify extended types using keys 'visual_typename' and/or 'visual_location_typename' as needed
+        Additional key 'hidden' can pass a list of keys which will not be visible to the visual location buffer
         """
         #subtract start_time from initial_time
         start_time = self.initial_time - start_time

--- a/pyactr/environment.py
+++ b/pyactr/environment.py
@@ -74,7 +74,9 @@ class Environment(object):
 
         Arbitrary visual attributes can be added as keys within each stimulus dictionary
         You must also specify extended types using keys 'visual_typename' and/or 'visual_location_typename' as needed
-        Additional key 'hidden' can pass a list of keys which will not be visible to the visual location buffer
+        Additional key 'externally_visible' can pass a list of keys which will be visible to the visual location buffer
+        (Use this key with caution: visual_location searches cannot return an object if it contains
+        an externally-visible attribute that is not present in the search)
         """
         #subtract start_time from initial_time
         start_time = self.initial_time - start_time

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -343,6 +343,7 @@ class Visual(buffers.Buffer):
                 if self.environment.stimulus[each]['position'] == (float(mod_attr_val['screen_pos'].values.screen_x.values), float(mod_attr_val['screen_pos'].values.screen_y.values)):
                     vis_delay = self.environment.stimulus[each].get('vis_delay')
                     stim = self.environment.stimulus[each]
+                    stim.update({'cmd': mod_attr_val['cmd']})
             except (AttributeError, KeyError):
                 raise ACTRError("The chunk in the visual buffer is not defined correctly. It is not possible to move attention.")
 
@@ -393,6 +394,7 @@ def chunk_from_stimulus(stimulus, buffer, position=True):
     # if adding to the visual buffer, these will be encoded, with 'text' as 'value'
     stim_hidden = ['text']
     if buffer == "visual_location":
+        stim_hidden.append('cmd')
         try:
             stim_hidden += stimulus.get('hidden', [])
         except AttributeError:

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -244,8 +244,6 @@ class Visual(buffers.Buffer):
     Visual buffer. This sees objects in the environment.
     """
 
-    _VISUAL = utilities.VISUAL
-
     def __init__(self, environment, default_harvest=None):
         self.environment = environment
         buffers.Buffer.__init__(self, default_harvest, None)

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -375,19 +375,19 @@ class Visual(buffers.Buffer):
         """
         return getattr(self, state) == inquiry
 
-def chunk_from_stimulus(stimulus, buffer, position=True):
+def chunk_from_stimulus(stimulus, buffer_name, position=True):
     """
     Given a stimulus dict from the environment, a buffer name, and flags, returns a chunk
     Flags for whether to encode position, whether to hide some attributes, and whether to copy in a location chunk
     """
     # extract a possible extended chunk type from the stimulus
     # defaults to utilities.VISUALLOCATION/.VISUAL
-    if buffer == "visual_location":
-        stim_typename = stimulus.get(buffer+"_typename", utilities.VISUALLOCATION)
-    elif buffer == "visual":
-        stim_typename = stimulus.get(buffer+"_typename", utilities.VISUAL)
+    if buffer_name == "visual_location":
+        stim_typename = stimulus.get(buffer_name + "_typename", utilities.VISUALLOCATION)
+    elif buffer_name == "visual":
+        stim_typename = stimulus.get(buffer_name + "_typename", utilities.VISUAL)
     else:
-        raise ValueError("buffer must be either ""visual_location"" or ""visual""")
+        raise ValueError("buffer_name must be either ""visual_location"" or ""visual""")
 
     # a list of reserved values for control parameters, never encoded into the chunk
     stim_control = ['text', 'position', 'vis_delay', 'visual_location_typename', 'visual_typename', 'externally_visible']
@@ -398,7 +398,7 @@ def chunk_from_stimulus(stimulus, buffer, position=True):
     # be careful when adding to stimulus['externally_visible']: visual search checks if the stimulus chunk subsumes the search chunk...
     # ... so ALL externally visible features of a stimulus must be included in a search in order to fixate it
 
-    if buffer == "visual_location":
+    if buffer_name == "visual_location":
         visible_features = []
         try:
             visible_features += stimulus.get('externally_visible', [])
@@ -411,7 +411,7 @@ def chunk_from_stimulus(stimulus, buffer, position=True):
     if position:
         temp_dict.update({'screen_x': int(stimulus['position'][0]),
                           'screen_y': int(stimulus['position'][1])})
-    if buffer == "visual":
+    if buffer_name == "visual":
         location = chunk_from_stimulus(stimulus, "visual_location")
         temp_dict.update({'screen_pos': location})
         temp_dict.update({'value': stimulus.get('text', '')})

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -342,7 +342,7 @@ class Visual(buffers.Buffer):
             try:
                 if self.environment.stimulus[each]['position'] == (float(mod_attr_val['screen_pos'].values.screen_x.values), float(mod_attr_val['screen_pos'].values.screen_y.values)):
                     vis_delay = self.environment.stimulus[each].get('vis_delay')
-                    stim = self.environment.stimulus[each]
+                    stim = self.environment.stimulus[each].copy()
                     stim.update({'cmd': mod_attr_val['cmd']})
             except (AttributeError, KeyError):
                 raise ACTRError("The chunk in the visual buffer is not defined correctly. It is not possible to move attention.")
@@ -391,7 +391,7 @@ def chunk_from_stimulus(stimulus, buffer, position=True):
 
     # a list of values in the stimulus object to leave out of the chunk
     # by default, this is just 'text', but additional ones to skip are merged from stimulus['hidden']
-    # if adding to the visual buffer, these will be encoded, with 'text' as 'value'
+    # if adding to the visual buffer, these will be encoded (with 'text' as 'value', see below)
     stim_hidden = ['text']
     if buffer == "visual_location":
         stim_hidden.append('cmd')
@@ -399,8 +399,6 @@ def chunk_from_stimulus(stimulus, buffer, position=True):
             stim_hidden += stimulus.get('hidden', [])
         except AttributeError:
             raise ValueError("stimulus['hidden'] should be a list of strings")
-    else:
-        stimulus.update({'value': stimulus.get('text', '')})
 
     # a list of reserved values for control parameters, never encoded into the chunk
     stim_control = ['position', 'vis_delay', 'visual_location_typename', 'visual_typename', 'hidden']
@@ -412,6 +410,7 @@ def chunk_from_stimulus(stimulus, buffer, position=True):
     if buffer == "visual":
         location = chunk_from_stimulus(stimulus, "visual_location")
         temp_dict.update({'screen_pos': location})
+        temp_dict.update({'value': stimulus.get('text', '')})
     visible_chunk = chunks.Chunk(stim_typename, **temp_dict)
 
     return visible_chunk

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -301,7 +301,7 @@ class Visual(buffers.Buffer):
         model_parameters = model_parameters.copy()
         model_parameters.update(self.model_parameters)
 
-        new_chunk = chunk_from_stimulus(stim, hide=False, copy_loc=True)
+        new_chunk = chunk_from_stimulus(stim, position=False, hide=False, copy_loc=True)
         
         if new_chunk:
             angle_distance = 2*utilities.calculate_visual_angle(self.environment.current_focus, (stim['position'][0], stim['position'][1]), self.environment.size, self.environment.simulated_screen_size, self.environment.viewing_distance) #the stimulus has to be within 2 degrees from the focus (foveal region)
@@ -342,10 +342,11 @@ class Visual(buffers.Buffer):
             try:
                 if self.environment.stimulus[each]['position'] == (float(mod_attr_val['screen_pos'].values.screen_x.values), float(mod_attr_val['screen_pos'].values.screen_y.values)):
                     vis_delay = self.environment.stimulus[each].get('vis_delay')
+                    stim = self.environment.stimulus[each]
             except (AttributeError, KeyError):
                 raise ACTRError("The chunk in the visual buffer is not defined correctly. It is not possible to move attention.")
 
-        new_chunk = chunks.Chunk(self._VISUAL, **mod_attr_val) #creates new chunk
+        new_chunk = chunk_from_stimulus(stim, position=False, hide=False, copy_loc=True) #creates new chunk
 
         if model_parameters['emma']:
             angle_distance = utilities.calculate_visual_angle(self.environment.current_focus, [float(new_chunk.screen_pos.values.screen_x.values), float(new_chunk.screen_pos.values.screen_y.values)], self.environment.size, self.environment.simulated_screen_size, self.environment.viewing_distance)

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -375,8 +375,7 @@ class Visual(buffers.Buffer):
 
 def chunk_from_stimulus(stimulus, buffer_name, position=True):
     """
-    Given a stimulus dict from the environment, a buffer name, and flags, returns a chunk
-    Flags for whether to encode position, whether to hide some attributes, and whether to copy in a location chunk
+    Given a stimulus dict from the environment, a buffer name, and whether to encode position, returns a chunk to be used in that buffer.
     """
     # extract a possible extended chunk type from the stimulus
     # defaults to utilities.VISUALLOCATION/.VISUAL


### PR DESCRIPTION
Adds support for arbitrarily complex visual stimuli, resolves #36.

I prepared the visual system to deal with stimulus dictionaries with keys specifying extended chunktypes (`'visual_location_chunktype'` and `'visual_chunktype'`) for the objects those stimuli will create in the visual buffers. To do this, I added a helper function `chunk_from_stimulus()` in vision.py, which handles the creation of a chunk using these keys in the stimulus dictionary, as well as an additional key `'hidden'` which is expected to bear a list of keys which should be ignored when creating chunks in the `visual_location` buffer (in addition to `'text'`, which has this behavior as default). This helper function is now called in the four methods that create visual chunks from the environment: `VisualLocation.find()`, `VisualLocation.automatic_search()`, `Visual.automatic_buffering()`, and `Visual.shift()`. It doesn't change the behavior of standard visual functions in the absence of the special stimulus keys, and passes the unit tests.

In the process, I also:
- added support for defining chunktypes as extensions of an ancestor, as an `include` parameter to the `chunktype()` function, which takes the name of an existing chunktype and includes all the existing chunktype's attributes in the new chunktype, mirroring the behavior of `:include` in Lisp ACT-R
- corrected a bug that meant the built-in 'color' attributes were also usually not getting copied over into the Visual Buffer

Here's a sample model and corresponding trace to demonstrate the intended functionality:

```python
import pyactr as actr

env = actr.Environment(focus_position=(0, 0))
model = actr.ACTRModel(
    environment=env,
    automatic_visual_search=True,
    motor_prepared=True,
    strict_harvesting=False,
    emma=False
)

actr.chunktype("shape", ('shape', 'texture'), include='_visual')

dm = model.decmem
model.set_goal(name="imaginal", delay=0.2)
model.visualBuffer("visual", "visual_location", default_harvest=dm, finst=4)

model.productionstring(name="encodeVisual", string="""
    =visual_location>
        isa _visuallocation
==>
    +visual>
        isa _visual
        cmd         move_attention
        screen_pos  =visual_location
    ~visual_location>
""")

stimulus = {0: {'position': (100,100),
                'shape': 'triangle',
                'texture': 'striped',
                'color': 'gold',
                'visual_typename': 'shape',
                'hidden': ['shape', 'texture']}}

sim = model.simulation(realtime=False,
                       gui=False,
                       environment_process=env.environment_process,
                       stimuli=stimulus,
                       triggers='',
                       times=100
                       )
sim.run()
```

```
(0, 'PROCEDURAL', 'CONFLICT RESOLUTION')
(0, 'PROCEDURAL', 'NO RULE FOUND')
****Environment: {0: {'position': (100, 100), 'shape': 'triangle', 'texture': 'striped', 'color': 'gold', 'visual_typename': 'shape', 'hidden': ['shape', 'texture']}}
(0, 'visual_location', 'ENCODED LOCATION: _visuallocation(color= gold, screen_x= 100, screen_y= 100, value= )')
(0, 'PROCEDURAL', 'CONFLICT RESOLUTION')
(0, 'PROCEDURAL', 'RULE SELECTED: encodeVisual')
(0.05, 'PROCEDURAL', 'RULE FIRED: encodeVisual')
(0.05, 'visual_location', 'CLEARED')
(0.05, 'visual', 'PREPARATION TO SHIFT VISUAL ATTENTION STARTED')
(0.05, 'visual', 'PREPARATION TO SHIFT VISUAL ATTENTION COMPLETED')
(0.05, 'PROCEDURAL', 'CONFLICT RESOLUTION')
(0.05, 'PROCEDURAL', 'NO RULE FOUND')
(0.135, 'visual', 'CLEARED')
(0.135, 'visual', "ENCODED VIS OBJECT:'shape(cmd= move_attention, color= gold, screen_pos= _visuallocation(color= gold, screen_x= 100, screen_y= 100, value= ), shape= triangle, texture= striped, value= )'")
(0.135, 'visual', 'SHIFT COMPLETE TO POSITION: [100, 100]')
(0.135, 'PROCEDURAL', 'CONFLICT RESOLUTION')
(0.135, 'PROCEDURAL', 'NO RULE FOUND')
```