### PR TITLE
Replace deprecated parseString

### DIFF
--- a/pyactr/chunks.py
+++ b/pyactr/chunks.py
@@ -469,7 +469,7 @@ def chunkstring(name='', string=''):
     chunktype_example0(value= one)
     """
     chunk_reader = utilities.getchunk()
-    chunk = chunk_reader.parseString(string, parseAll=True)
+    chunk = chunk_reader.parse_string(string, parse_all=True)
     try:
         type_chunk, chunk_dict = createchunkdict(chunk)
     except utilities.ACTRError as e:

--- a/pyactr/model.py
+++ b/pyactr/model.py
@@ -243,7 +243,7 @@ class ACTRModel(object):
         temp_dictLHS = {v: k for k, v in utilities._LHSCONVENTIONS.items()}
         rule_reader = utilities.getrule()
         try:
-            rule = rule_reader.parseString(string, parseAll=True)
+            rule = rule_reader.parse_string(string, parse_all=True)
         except pyparsing.ParseException as e:
             raise(utilities.ACTRError("The rule '%s' could not be parsed. The following error was observed: %s" %(name, e)))
         lhs, rhs = {}, {}


### PR DESCRIPTION
parseString becomes parse_string:
https://pyparsing-docs.readthedocs.io/en/latest/pyparsing.html#pyparsing.ParserElement.parseString

parseAll becomes parse_all:
https://pyparsing-docs.readthedocs.io/en/latest/pyparsing.html#pyparsing.ParserElement.parse_string