### PR TITLE
{style} Prefer "from pyactr import X" to "import pyactr.X as X"

### DIFF
--- a/pyactr/buffers.py
+++ b/pyactr/buffers.py
@@ -4,8 +4,7 @@ General class on buffers.
 
 import collections.abc
 
-import pyactr.chunks as chunks
-import pyactr.utilities as utilities
+from pyactr import chunks, utilities
 
 class Buffer(collections.abc.MutableSet):
     """

--- a/pyactr/chunks.py
+++ b/pyactr/chunks.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 import re
 import warnings
 
-import pyactr.utilities as utilities
+from pyactr import utilities
 from pyactr.utilities import ACTRError
 
 def chunktype(cls_name, field_names, defaults=None):

--- a/pyactr/declarative.py
+++ b/pyactr/declarative.py
@@ -8,9 +8,7 @@ import math
 
 import numpy as np
 
-import pyactr.chunks as chunks
-import pyactr.utilities as utilities
-import pyactr.buffers as buffers
+from pyactr import buffers, chunks, utilities
 
 class DecMem(collections.abc.MutableMapping):
     """

--- a/pyactr/environment.py
+++ b/pyactr/environment.py
@@ -4,7 +4,7 @@ Environment used for ACT-R model.
 
 import collections.abc
 
-import pyactr.utilities as utilities
+from pyactr import utilities
 
 class Environment(object):
     """

--- a/pyactr/goals.py
+++ b/pyactr/goals.py
@@ -2,10 +2,8 @@
 Goals.
 """
 
-import pyactr.chunks as chunks
-import pyactr.utilities as utilities
+from pyactr import buffers, chunks, utilities
 from pyactr.utilities import ACTRError
-import pyactr.buffers as buffers
 
 class Goal(buffers.Buffer):
     """

--- a/pyactr/model.py
+++ b/pyactr/model.py
@@ -4,14 +4,7 @@ ACT-R Model.
 
 import pyparsing
 
-import pyactr.chunks as chunks
-import pyactr.goals as goals
-import pyactr.productions as productions
-import pyactr.utilities as utilities
-import pyactr.declarative as declarative
-import pyactr.motor as motor
-import pyactr.vision as vision
-import pyactr.simulation as simulation
+from pyactr import chunks, declarative, goals, motor, productions, simulation, utilities, vision
 
 class ACTRModel(object):
     """

--- a/pyactr/motor.py
+++ b/pyactr/motor.py
@@ -2,10 +2,8 @@
 Motor module. Carries out key presses.
 """
 
-import pyactr.chunks as chunks
-import pyactr.utilities as utilities
+from pyactr import buffers, chunks, utilities
 from pyactr.utilities import ACTRError
-import pyactr.buffers as buffers
 
 class Motor(buffers.Buffer):
     """

--- a/pyactr/productions.py
+++ b/pyactr/productions.py
@@ -6,12 +6,7 @@ import collections
 import collections.abc
 import inspect
 
-import pyactr.declarative as declarative
-import pyactr.chunks as chunks
-import pyactr.goals as goals
-import pyactr.vision as vision
-import pyactr.motor as motor
-import pyactr.utilities as utilities
+from pyactr import chunks, declarative, goals, motor, utilities, vision
 from pyactr.utilities import ACTRError
 
 Event = utilities.Event

--- a/pyactr/simulation.py
+++ b/pyactr/simulation.py
@@ -3,6 +3,9 @@ ACT-R simulations.
 """
 
 import warnings
+import simpy
+
+from pyactr import utilities, vision
 
 try:
     import tkinter as tk
@@ -15,12 +18,6 @@ if GUI:
     import threading
     import queue
     import time
-
-import simpy
-
-import pyactr.utilities as utilities
-import pyactr.vision as vision
-import pyactr.chunks as chunks
 
 Event = utilities.Event
 

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -4,10 +4,8 @@ Vision module. Just basic.
 
 import collections
 
-import pyactr.chunks as chunks
-import pyactr.utilities as utilities
+from pyactr import buffers, chunks, utilities
 from pyactr.utilities import ACTRError
-import pyactr.buffers as buffers
 
 #TODO
 #setting ERROR/FREE should work even in buffers that can be interrupted -- check it does


### PR DESCRIPTION
Easier to read and we can import multiple things at once.