### PR TITLE
fix newchunk.key not matching

### DIFF
--- a/pyactr/productions.py
+++ b/pyactr/productions.py
@@ -898,7 +898,7 @@ class ProductionRules:
 
         time_presses = None #used for time stamps of 4 phases of motor
         for elem in motorbuffer.TIME_PRESSES.keys():
-            if newchunk.key in elem:
+            if str(newchunk.key) in elem:
                 time_presses = motorbuffer.TIME_PRESSES[elem]
         if not time_presses:
             time_presses = motorbuffer.TIME_PRESSES[()] #if not pressing or slowest, use default (short mvt)


### PR DESCRIPTION
This is an attempt at fixing a bug in motor time calculation.
The issue is that `newchunk.key` is never in `elem`, because `elem` is a tuple of strings
while the `newchunk.key` is an instance of `pyactr.utilities._variablesvalues`. Wrapping `newchunk.key` in `str()` fixes this at least partially. 
Partially because `TIME_PRESSES.keys()` returns 
`dict_keys([('A', 'S', 'D', 'F', 'J', 'K', 'L', 'SPACE'), ('5', '6'), ()])` and so this won't work in the last case (but maybe this is intended). 