### PR TITLE
Use f-strings for readability

### DIFF
--- a/pyactr/buffers.py
+++ b/pyactr/buffers.py
@@ -103,7 +103,7 @@ class Buffer(collections.abc.MutableSet):
         try:
             mod_attr_val = {x[0]: utilities.check_bound_vars(actrvariables, x[1]) for x in otherchunk.removeunused()} #creates dict of attr-val pairs according to otherchunk
         except utilities.ACTRError as arg:
-            raise utilities.ACTRError("The modification by the chunk '%s is impossible; %s" % (otherchunk, arg))
+            raise utilities.ACTRError(f"The modification by the chunk '{otherchunk} is impossible; {arg}")
         elem_attr_val = {x[0]: x[1] for x in elem}
         elem_attr_val.update(mod_attr_val) #updates original chunk with attr-val from otherchunk
         mod_chunk = chunks.Chunk(otherchunk.typename, **elem_attr_val) #creates new chunk

--- a/pyactr/chunks.py
+++ b/pyactr/chunks.py
@@ -22,7 +22,7 @@ def chunktype(cls_name, field_names, defaults=None, include=None):
     :param defaults: default values for the slots, given as an iterable, counting from the last element
     """
     if cls_name in utilities.SPECIALCHUNKTYPES and field_names != utilities.SPECIALCHUNKTYPES[cls_name]:
-        raise ACTRError("You cannot redefine slots of the chunk type '%s'; you can only use the slots '%s'" % (cls_name, utilities.SPECIALCHUNKTYPES[cls_name]))
+        raise ACTRError(f"You cannot redefine slots of the chunk type '{cls_name}'; you can only use the slots '{utilities.SPECIALCHUNKTYPES[cls_name]}'")
 
     try:
         field_names = field_names.replace(',', ' ').split()
@@ -94,7 +94,6 @@ class Chunk(Sequence):
 
         kwargs = {}
         for key in dictionary:
-
             #change values (and values in a tuple) into string, when possible (when the value is not another chunk)
             if isinstance(dictionary[key], Chunk):
                 dictionary[key] = utilities.VarvalClass(variables=None, values=dictionary[key], negvariables=(), negvalues=())
@@ -108,14 +107,14 @@ class Chunk(Sequence):
                         raise TypeError("Negvalues and negvariables must be tuples")
 
             elif (isinstance(dictionary[key], collections.abc.Iterable) and not isinstance(dictionary[key], str)) or not isinstance(dictionary[key], collections.abc.Hashable):
-                raise ValueError("The value of a chunk slot must be hashable and not iterable; you are using an illegal type for the value of the chunk slot %s, namely %s" % (key, type(dictionary[key])))
+                raise ValueError(f"The value of a chunk slot must be hashable and not iterable; you are using an illegal type for the value of the chunk slot {key}, namely {type(dictionary[key])}")
 
             else:
                 #create namedtuple varval and split dictionary[key] into variables, values, negvariables, negvalues
                 try:
                     temp_dict = utilities.stringsplitting(str(dictionary[key]))
                 except utilities.ACTRError as e:
-                    raise utilities.ACTRError("The chunk %s is not defined correctly; %s" %(dictionary[key], e))
+                    raise utilities.ACTRError(f"The chunk {dictionary[key]} is not defined correctly; {e}")
                 loop_dict = temp_dict.copy()
                 for x in loop_dict:
                     if x == "negvariables" or x == "negvalues":
@@ -141,12 +140,12 @@ class Chunk(Sequence):
             if set(self._chunktypes[typename]._fields) != set(kwargs.keys()):
 
                 chunktype(typename, dictionary.keys())  #If there are more args than in the original chunktype, chunktype has to be created again, with slots for new attributes
-                warnings.warn("Chunk type %s is extended with new attributes" % typename)
+                warnings.warn(f"Chunk type {typename} is extended with new attributes")
 
         except KeyError:
 
             chunktype(typename, dictionary.keys())  #If chunktype completely missing, it is created first
-            warnings.warn("Chunk type %s was not defined; added automatically" % typename)
+            warnings.warn(f"Chunk type {typename} was not defined; added automatically")
 
         finally:
             self.actrchunk = self._chunktypes[typename](**kwargs)
@@ -225,11 +224,11 @@ class Chunk(Sequence):
             elif isinstance(y, self.EmptyValue):
                 y = ""
             if reprtxt:
-                reprtxt = ", ".join([reprtxt, '%s= %s' % (x, y)])
+                reprtxt = ", ".join([reprtxt, f"{x}= {y}"])
             elif x:
-                reprtxt = '%s= %s' % (x, y)
+                reprtxt = f"{x}= {y}"
             else:
-                reprtxt = '%s' % y
+                reprtxt = y
         return "".join([self.typename, "(", reprtxt, ")"])
 
     def __lt__(self, otherchunk):
@@ -413,7 +412,7 @@ def createchunkdict(chunk):
         chunk_dict[key]["negvariables"] = tuple(chunk_dict[key]["negvariables"])
         for x in ["values", "variables"]:
             if len(chunk_dict[key][x]) > 1:
-                raise utilities.ACTRError("Any slot must have fewer than two %s, there is more than one in this slot" %x)
+                raise utilities.ACTRError(f"Any slot must have fewer than two {x}, there is more than one in this slot")
             elif len(chunk_dict[key][x]) == 1:
                 chunk_dict[key][x] = chunk_dict[key][x].pop()
             else:
@@ -459,7 +458,7 @@ def makechunk(nameofchunk="", typename="", **dictionary):
             try:
                 temp_dict = utilities.stringsplitting(str(dictionary[key]))
             except utilities.ACTRError as e:
-                raise utilities.ACTRError("The chunk value %s is not defined correctly; %s" %(dictionary[key], e))
+                raise utilities.ACTRError(f"The chunk value {dictionary[key]} is not defined correctly; {e}")
             loop_dict = temp_dict.copy()
             for x in loop_dict:
                 if x == "negvariables" or x == "negvalues":
@@ -489,7 +488,7 @@ def chunkstring(name='', string=''):
     try:
         type_chunk, chunk_dict = createchunkdict(chunk)
     except utilities.ACTRError as e:
-        raise utilities.ACTRError("The chunk string %s is not defined correctly; %s" %(string, e))
+        raise utilities.ACTRError(f"The chunk string {string} is not defined correctly; {e}")
 
     created_chunk = makechunk(name, type_chunk, **chunk_dict)
     return created_chunk

--- a/pyactr/declarative.py
+++ b/pyactr/declarative.py
@@ -63,7 +63,7 @@ class DecMem(collections.abc.MutableMapping):
                 except TypeError:
                     self._data[key] = np.array(time)
         else:
-            raise utilities.ACTRError("Only chunks can be added as attributes to Declarative Memory; '%s' is not a chunk" % key)
+            raise utilities.ACTRError(f"Only chunks can be added as attributes to Declarative Memory; '{key}' is not a chunk")
     
     def add_activation(self, element, activation):
         """
@@ -74,7 +74,7 @@ class DecMem(collections.abc.MutableMapping):
         if element in self:
             self.activations[element] = activation
         else:
-            raise AttributeError("The chunk %s is not in the declarative memory." % element)
+            raise AttributeError(f"The chunk {element} is not in the declarative memory.")
 
     def add(self, element, time=0):
         """
@@ -192,7 +192,7 @@ class DecMemBuffer(buffers.Buffer):
         try:
             mod_attr_val = {x[0]: utilities.check_bound_vars(actrvariables, x[1], negative_impossible=False) for x in otherchunk.removeunused()}
         except utilities.ACTRError as arg:
-            raise utilities.ACTRError("Retrieving the chunk '%s' is impossible; %s" % (otherchunk, arg))
+            raise utilities.ACTRError(f"Retrieving the chunk '{otherchunk}' is impossible; {arg}")
         chunk_tobe_matched = chunks.Chunk(otherchunk.typename, **mod_attr_val)
 
         max_A = float("-inf")
@@ -223,7 +223,7 @@ class DecMemBuffer(buffers.Buffer):
                 except UnboundLocalError:
                     continue
                 if math.isnan(A_bll):
-                    raise utilities.ACTRError("The following chunk cannot receive base activation: %s. The reason is that one of its traces did not appear in a past moment." % chunk)
+                    raise utilities.ACTRError(f"The following chunk cannot receive base activation: {chunk}. The reason is that one of its traces did not appear in a past moment.")
                 A_sa = utilities.spreading_activation(chunk, buffers, self.dm, model_parameters["buffer_spreading_activation"], model_parameters["strength_of_association"], model_parameters["spreading_activation_restricted"], model_parameters["association_only_from_chunks"])
                 inst_noise = utilities.calculate_instantaneous_noise(model_parameters["instantaneous_noise"])
                 A = A_bll + A_sa + A_pm + inst_noise #chunk.activation is the manually specified activation, potentially used by the modeller

--- a/pyactr/goals.py
+++ b/pyactr/goals.py
@@ -81,7 +81,7 @@ class Goal(buffers.Buffer):
         """
         Retrieve a chunk. This is not possible in goal buffer, so an error is raised.
         """
-        raise utilities.ACTRError("An attempt to retrieve from goal in the chunk '%s'; retrieving from goal is not possible" % otherchunk)
+        raise utilities.ACTRError(f"An attempt to retrieve from goal in the chunk '{otherchunk}'; retrieving from goal is not possible")
 
 
     def create(self, otherchunk, harvest=None, actrvariables=None):
@@ -91,10 +91,8 @@ class Goal(buffers.Buffer):
         try:
             mod_attr_val = {x[0]: utilities.check_bound_vars(actrvariables, x[1]) for x in otherchunk.removeunused()} #creates dict of attr-val pairs according to otherchunk
         except utilities.ACTRError as arg:
-            raise utilities.ACTRError("Setting the buffer using the chunk '%s' is impossible; %s" % (otherchunk, arg))
+            raise utilities.ACTRError(f"Setting the buffer using the chunk '{otherchunk}' is impossible; {arg}")
 
         new_chunk = chunks.Chunk(otherchunk.typename, **mod_attr_val) #creates new chunk
 
         self.add(new_chunk, 0, harvest) #put chunk using add
-
-

--- a/pyactr/model.py
+++ b/pyactr/model.py
@@ -101,7 +101,9 @@ class ACTRModel:
 
         try:
             if not set(model_parameters.keys()).issubset(set(self.MODEL_PARAMETERS.keys())):
-                raise(utilities.ACTRError("Incorrect model parameter(s) %s. The only possible model parameters are: '%s'" % (set(model_parameters.keys()).difference(set(self.MODEL_PARAMETERS.keys())), set(self.MODEL_PARAMETERS.keys()))))
+                params = set(model_parameters.keys()).difference(set(self.MODEL_PARAMETERS.keys()))
+                allowed_params = set(self.MODEL_PARAMETERS.keys())
+                raise utilities.ACTRError(f"Incorrect model parameter(s) {params}. The only possible model parameters are: '{allowed_params}'")
             self.model_parameters.update(model_parameters)
         except TypeError:
             pass
@@ -115,8 +117,8 @@ class ACTRModel:
         """
         if len(self.retrievals) == 1:
             return list(self.retrievals.values())[0]
-        else:
-            raise(ValueError("Zero or more than 1 retrieval specified, unclear which one should be shown. Use ACTRModel.retrievals instead."))
+
+        raise ValueError("Zero or more than 1 retrieval specified, unclear which one should be shown. Use ACTRModel.retrievals instead.")
 
     @retrieval.setter
     def retrieval(self, name):
@@ -129,8 +131,8 @@ class ACTRModel:
         """
         if len(self.decmems) == 1:
             return list(self.decmems.values())[0]
-        else:
-            raise(ValueError("Zero or more than 1 declarative memory specified, unclear which one should be shown. Use ACTRModel.decmems instead."))
+
+        raise ValueError("Zero or more than 1 declarative memory specified, unclear which one should be shown. Use ACTRModel.decmems instead.")
     
     @decmem.setter
     def decmem(self, data):
@@ -155,7 +157,7 @@ class ACTRModel:
         if len(self.goals) == 1:
             return list(self.goals.values())[0]
         else:
-            raise(ValueError("Zero or more than 1 goal specified, unclear which one should be shown. Use ACTRModel.goals instead."))
+            raise ValueError("Zero or more than 1 goal specified, unclear which one should be shown. Use ACTRModel.goals instead.")
     
     @goal.setter
     def goal(self, name):
@@ -168,7 +170,7 @@ class ACTRModel:
         name: the name by which the retrieval buffer is referred to in production rules.
         """
         if not isinstance(name, str):
-            raise(ValueError("Retrieval buffer can be only set with a string, the name of the retrieval buffer."))
+            raise ValueError("Retrieval buffer can be only set with a string, the name of the retrieval buffer.")
         dmb = declarative.DecMemBuffer()
         self.__buffers[name] = dmb
         self.retrievals[name] = dmb
@@ -181,7 +183,7 @@ class ACTRModel:
         name: the name by which the goal buffer is referred to in production rules.
         """
         if not isinstance(name, str):
-            raise(ValueError("Goal buffer can be only set with a string, the name of the goal buffer."))
+            raise ValueError("Goal buffer can be only set with a string, the name of the goal buffer.")
         g = goals.Goal(delay=delay)
         self.__buffers[name] = g
         self.goals[name] = g
@@ -238,7 +240,7 @@ class ACTRModel:
         try:
             rule = rule_reader.parse_string(string, parse_all=True)
         except pyparsing.ParseException as e:
-            raise(utilities.ACTRError("The rule '%s' could not be parsed. The following error was observed: %s" %(name, e)))
+            raise utilities.ACTRError(f"The rule '{name}' could not be parsed. The following error was observed: {e}")
         lhs, rhs = {}, {}
         def func():
             for each in rule[0]:
@@ -248,7 +250,7 @@ class ACTRModel:
                     try:
                         type_chunk, chunk_dict = chunks.createchunkdict(each[3])
                     except utilities.ACTRError as e:
-                        raise utilities.ACTRError("The rule string %s is not defined correctly; %s" %(name, e))
+                        raise utilities.ACTRError(f"The rule string {name} is not defined correctly; {e}")
                     lhs[each[0]+each[1]] = chunks.makechunk("", type_chunk, **chunk_dict)
             yield lhs
             for each in rule[2]:
@@ -262,7 +264,7 @@ class ACTRModel:
                     try:
                         type_chunk, chunk_dict = chunks.createchunkdict(each[3])
                     except utilities.ACTRError as e:
-                        raise utilities.ACTRError("The rule string %s is not defined correctly; %s" %(name, e))
+                        raise utilities.ACTRError(f"The rule string {name} is not defined correctly; {e}")
                     rhs[each[0]+each[1]] = chunks.makechunk("", type_chunk, **chunk_dict)
             yield rhs
         self.productions.update({name: {"rule": func, "utility": utility, "reward": reward}})

--- a/pyactr/motor.py
+++ b/pyactr/motor.py
@@ -48,19 +48,18 @@ class Motor(buffers.Buffer):
         try:
             mod_attr_val = {x[0]: utilities.check_bound_vars(actrvariables, x[1]) for x in otherchunk.removeunused()} #creates dict of attr-val pairs according to otherchunk
         except ACTRError as arg:
-            raise ACTRError("Setting the chunk '%s' in the manual buffer is impossible; %s" % (otherchunk, arg))
+            raise ACTRError(f"Setting the chunk '{otherchunk}' in the manual buffer is impossible; {arg}")
 
         new_chunk = chunks.Chunk(self._MANUAL, **mod_attr_val) #creates new chunk
 
         if new_chunk.cmd.values not in utilities.CMDMANUAL:
-            raise ACTRError("Motor module received an invalid command: '%s'. The valid commands are: '%s'" % (new_chunk.cmd.values, utilities.CMDMANUAL))
+            raise ACTRError(f"Motor module received an invalid command: '{new_chunk.cmd.values}'. The valid commands are: '{utilities.CMDMANUAL}'")
 
         if new_chunk.cmd.values == utilities.CMDPRESSKEY:
             pressed_key = new_chunk.key.values.upper() #change key into upper case
             mod_attr_val["key"] = pressed_key
             new_chunk = chunks.Chunk(self._MANUAL, **mod_attr_val) #creates new chunk
         if pressed_key not in self.LEFT_HAND and new_chunk.key.values not in self.RIGHT_HAND:
-            raise ACTRError("Motor module received an invalid key: %s" % pressed_key)
+            raise ACTRError(f"Motor module received an invalid key: {pressed_key}")
 
         return new_chunk
-

--- a/pyactr/productions.py
+++ b/pyactr/productions.py
@@ -50,15 +50,15 @@ class Production(collections.UserDict):
         production = self["rule"]()
         utility = self["utility"]
         reward = self["reward"]
-        txt += '{}\n==>\n{}'.format(next(production), next(production))
+        txt += f"{next(production)}\n==>\n{next(production)}"
         if utility:
-            txt += "\nUtility: {}\n".format(utility)
+            txt += f"\nUtility: {utility}\n"
         if reward:
-            txt += "Reward: {}\n".format(reward)
+            txt += f"Reward: {reward}\n"
         return txt
 
     def __setitem__(self, key, value):
-        assert key in {"rule", "utility", "reward"}, "The production can set only one of four values -- rule, utility, reward; you are using '%s'" %key
+        assert key in {"rule", "utility", "reward"}, f"The production can set only one of four values -- rule, utility, reward; you are using '{key}'"
         self.rule[key] = value
 
 class Productions(collections.UserDict):
@@ -109,7 +109,7 @@ class Productions(collections.UserDict):
     def __repr__(self):
         txt = ''
         for rulename in self.rules:
-            txt += rulename + '{}\n'.format(self.rules[rulename])
+            txt += rulename + f"{self.rules[rulename]}\n"
         return txt
 
     def __setitem__(self, key, value):
@@ -517,14 +517,14 @@ class ProductionRules:
             production = self.rules[used_rulename]["rule"]()
             self.rules.used_rulenames.setdefault(used_rulename, []).append(time)
             
-            yield Event(roundtime(time), self._PROCEDURAL, 'RULE SELECTED: %s' % used_rulename)
+            yield Event(roundtime(time), self._PROCEDURAL, f"RULE SELECTED: {used_rulename}")
             time = time + self.model_parameters["rule_firing"]
             yield Event(roundtime(time), self._PROCEDURAL, self._UNKNOWN)
 
             pro = next(production)
 
             if not self.LHStest(pro, self.__actrvariables.copy(), True):
-                yield Event(roundtime(time), self._PROCEDURAL, 'RULE STOPPED FROM FIRING: %s' % used_rulename)
+                yield Event(roundtime(time), self._PROCEDURAL, f"RULE STOPPED FROM FIRING: {used_rulename}")
             else:
                 if self.model_parameters["utility_learning"] and self.rules[used_rulename]["reward"] != None:
                     utilities.modify_utilities(time, self.rules[used_rulename]["reward"], self.rules.used_rulenames, self.rules, self.model_parameters)
@@ -532,13 +532,13 @@ class ProductionRules:
                 compiled_rulename, re_created = self.compile_rules()
                 self.compile = []
                 if re_created:
-                    yield Event(roundtime(time), self._PROCEDURAL, 'RULE %s: %s' % (re_created, compiled_rulename))
+                    yield Event(roundtime(time), self._PROCEDURAL, f"RULE {re_created}: {compiled_rulename}")
                 self.current_slotvals = {key: None for key in self.buffers}
-                yield Event(roundtime(time), self._PROCEDURAL, 'RULE FIRED: %s' % used_rulename)
+                yield Event(roundtime(time), self._PROCEDURAL, f"RULE FIRED: {used_rulename}")
                 try:
                     yield from self.update(next(production), time)
                 except utilities.ACTRError as e:
-                    raise utilities.ACTRError("The following rule is not defined correctly according to ACT-R: '%s'. The following error occurred: %s" % (self.used_rulename, e))
+                    raise utilities.ACTRError(f"The following rule is not defined correctly according to ACT-R: '{self.used_rulename}'. The following error occurred: {e}")
                 if self.last_rule and self.last_rule != used_rulename:
                     self.compile = [self.last_rule, used_rulename, self.last_rule_slotvals.copy()]
                     self.last_rule_slotvals = {key: None for key in self.buffers}
@@ -570,7 +570,7 @@ class ProductionRules:
         try:
             dictionary = collections.OrderedDict.fromkeys(sorted(RHSdictionary, key=lambda x:ordering_dict[x[0]]))
         except KeyError:
-            raise ACTRError("The RHS rule '%s' is invalid; every condition in RHS rules must start with one of these signs: %s" % (self.used_rulename, list(self._RHSCONVENTIONS.keys())))
+            raise ACTRError(f"The RHS rule '{self.used_rulename}' is invalid; every condition in RHS rules must start with one of these signs: {list(self._RHSCONVENTIONS.keys())}")
         dictionary.update(RHSdictionary)
         for key in dictionary:
             submodule_name = key[1:] #this is the name of updated submodule
@@ -622,7 +622,7 @@ class ProductionRules:
                 try:
                     cleared.clear(time, self.dm[name]) #if nothing else works, check whether buffer instance was bound to a decl. mem by user
                 except KeyError:
-                    raise ACTRError("It is not specified to what memory the buffer %s should be cleared" % name)
+                    raise ACTRError(f"It is not specified to what memory the buffer {name} should be cleared")
         yield Event(roundtime(time), name, "CLEARED")
         if freeing:
             cleared.state = cleared._FREE
@@ -704,7 +704,7 @@ class ProductionRules:
 
         created_elem = list(updated)[0]
         updated.state = updated._FREE
-        yield Event(roundtime(time), name, "WROTE A CHUNK: %s" % str(created_elem))
+        yield Event(roundtime(time), name, f"WROTE A CHUNK: {str(created_elem)}")
 
     def visualencode(self, name, visualbuffer, chunk, temp_actrvariables, time, extra_time, site):
         """
@@ -716,7 +716,7 @@ class ProductionRules:
         yield from self.clear(name, visualbuffer, None, temp_actrvariables, time, freeing=False)
         visualbuffer.add(chunk, time)
         visualbuffer.state = visualbuffer._FREE
-        yield Event(roundtime(time), name, "ENCODED VIS OBJECT:'%s'" % str(chunk))
+        yield Event(roundtime(time), name, f"ENCODED VIS OBJECT:'{str(chunk)}'")
 
     def retrieveorset(self, name, updated, otherchunk, temp_actrvariables, time):
         """
@@ -736,7 +736,7 @@ class ProductionRules:
             updated.create(otherchunk, list(self.dm.values())[0], temp_actrvariables)
             created_elem = list(updated)[0]
             updated.state = updated._FREE
-            yield Event(roundtime(time), name, "CREATED A CHUNK: %s" % str(created_elem))
+            yield Event(roundtime(time), name, f"CREATED A CHUNK: {str(created_elem)}")
         elif isinstance(updated, vision.VisualLocation):
             extra_time = utilities.calculate_setting_time(updated)
             time += extra_time #0 ms to create chunk in location (pop-up effect)
@@ -748,11 +748,11 @@ class ProductionRules:
                 updated.state = updated._FREE
             else:
                 updated.state = updated._ERROR
-            yield Event(roundtime(time), name, "ENCODED LOCATION:'%s'" % str(chunk))
+            yield Event(roundtime(time), name, f"ENCODED LOCATION:'{str(chunk)}'")
         elif isinstance(updated, vision.Visual):
             mod_attr_val = {x[0]: utilities.check_bound_vars(temp_actrvariables, x[1]) for x in otherchunk.removeunused()}
             if (not mod_attr_val['cmd'].values) or mod_attr_val['cmd'].values not in utilities.CMDVISUAL:
-                raise ACTRError("Visual module received no command or an invalid command: '%s'. The valid commands are: '%s'" % (mod_attr_val['cmd'].values, utilities.CMDVISUAL))
+                raise ACTRError(f"Visual module received no command or an invalid command: '{mod_attr_val['cmd'].values}'. The valid commands are: '{utilities.CMDVISUAL}'")
             if mod_attr_val['cmd'].values == utilities.CMDMOVEATTENTION:
                 ret = yield from self.visualshift(name, updated, otherchunk, temp_actrvariables, time)
                 yield ret #visual action returns value, namely, its continuation method
@@ -787,7 +787,7 @@ class ProductionRules:
             RHSdict = {item[0]: item[1] for item in RHSdict.items() if item[1] != chunks.Chunk.EmptyValue()} #delete None values
             self.current_slotvals[name] = [RHSdict, retrieved_elem]
 
-        yield Event(roundtime(time), name, 'RETRIEVED: %s' % str(retrieved_elem))
+        yield Event(roundtime(time), name, f"RETRIEVED: {str(retrieved_elem)}")
 
     def automatic_search(self, name, visualbuffer, stim, time):
         """
@@ -802,7 +802,7 @@ class ProductionRules:
                 visualbuffer.modify(newchunk, stim)
             else:
                 visualbuffer.add(newchunk, stim, time)
-            yield Event(roundtime(time), name, 'ENCODED LOCATION: %s' %newchunk)
+            yield Event(roundtime(time), name, f"ENCODED LOCATION: {newchunk}")
         else:
             yield Event(roundtime(time), name, self._UNKNOWN)
 
@@ -829,7 +829,7 @@ class ProductionRules:
                 visualbuffer.modify(newchunk)
             else:
                 visualbuffer.add(newchunk, time)
-            yield Event(roundtime(time), name, 'AUTOMATIC BUFFERING: %s' % str(newchunk))
+            yield Event(roundtime(time), name, f"AUTOMATIC BUFFERING: {str(newchunk)}")
 
     def visualshift(self, name, visualbuffer, otherchunk, temp_actrvariables, time):
         """
@@ -878,7 +878,7 @@ class ProductionRules:
 
         yield Event(roundtime(time), name, self._UNKNOWN)
         visualbuffer.move_eye(landing_site)
-        yield Event(roundtime(time), name, 'SHIFT COMPLETE TO POSITION: %s' % str(visualbuffer.current_focus))
+        yield Event(roundtime(time), name, f"SHIFT COMPLETE TO POSITION: {str(visualbuffer.current_focus)}")
         if encoding > preparation+execution:
             newchunk, extra_time, _ = visualbuffer.shift(otherchunk, actrvariables=temp_actrvariables, model_parameters=self.model_parameters)
             yield from self.visualencode(name, visualbuffer, otherchunk, temp_actrvariables, time, (1-((preparation+execution)/encoding))*extra_time[0], landing_site)
@@ -918,7 +918,7 @@ class ProductionRules:
         motorbuffer.preparation = motorbuffer._BUSY
         motorbuffer.processor = motorbuffer._BUSY
 
-        yield Event(roundtime(time), name, 'COMMAND: %s' % str(newchunk.cmd))
+        yield Event(roundtime(time), name, f"COMMAND: {str(newchunk.cmd)}")
         time += preparation
         
         yield Event(roundtime(time), name, 'PREPARATION COMPLETE')
@@ -952,7 +952,7 @@ class ProductionRules:
         
         self.env_interaction.add(otherchunk.key.values)
 
-        yield Event(roundtime(time), name, 'KEY PRESSED: %s' % str(otherchunk.key))
+        yield Event(roundtime(time), name, f"KEY PRESSED: {str(otherchunk.key)}")
         
         time += movement_finish
 
@@ -971,7 +971,7 @@ class ProductionRules:
             submodule_name = key[1:] #this is the module
             code = key[0] #this is what the module should do; standardly, query, i.e., ?, or test, =
             if code not in self._LHSCONVENTIONS:
-                raise ACTRError("The LHS rule '%s' is invalid; every condition in LHS rules must start with one of these signs: %s" % (self.used_rulename, list(self._LHSCONVENTIONS.keys())))
+                raise ACTRError(f"The LHS rule '{self.used_rulename}' is invalid; every condition in LHS rules must start with one of these signs: {list(self._LHSCONVENTIONS.keys())}")
             result = getattr(self, self._LHSCONVENTIONS[code])(submodule_name, self.buffers.get(submodule_name), dictionary[key], actrvariables)
             if not result[0]:
                 return False

--- a/pyactr/simulation.py
+++ b/pyactr/simulation.py
@@ -170,7 +170,7 @@ class Simulation:
                     cont = yield pro
                 except simpy.Interrupt:
                     if not pro.triggered:
-                        warnings.warn("Process in %s interrupted" % name)
+                        warnings.warn(f"Process in {name} interrupted")
                         pro.interrupt() #interrupt process
 
                 #if first extra process is followed by another process (returned as cont), do what follows; used only for motor and visual

--- a/pyactr/utilities.py
+++ b/pyactr/utilities.py
@@ -181,14 +181,14 @@ def make_chunkparts_without_varconflicts(chunkpart, rule_name, variables):
     if varval.variables:
         new_name = "".join([str(varval.variables), "__rule__", rule_name])
         if "".join(["=", new_name]) in variables:
-            raise ACTRError("A name clash appeared when trying to compile two rules. Try to rename variables in the rule '%s'" %rule_name)
+            raise ACTRError(f"A name clash appeared when trying to compile two rules. Try to rename variables in the rule '{rule_name}'")
         else:
             temp_var = new_name
     temp_negvar = set()
     for x in varval.negvariables:
         new_name = "".join([str(x), "__rule__", rule_name])
         if "".join(["=", "new_name"]) in variables:
-            raise ACTRError("A name clash appeared when trying to compile two rules. Try to rename variables in the rule '%s'" %rule_name)
+            raise ACTRError(f"A name clash appeared when trying to compile two rules. Try to rename variables in the rule '{rule_name}'")
         else:
             temp_negvar.add(new_name)
     new_varval = VarvalClass(variables=temp_var, values=varval.values, negvariables=tuple(temp_negvar), negvalues=varval.negvalues)
@@ -210,7 +210,7 @@ def make_chunkparts_with_new_vars(chunkpart, variable_dict, val_dict):
                 if val_dict[varval.variables] == varval.values:
                     pass
                 else:
-                    raise ACTRError("During the compilation, one slot received two different values, namely %s and %s; exiting" %(varval.values, val_dict[varval.variables]))
+                    raise ACTRError(f"During the compilation, one slot received two different values, namely {varval.values} and {val_dict[varval.variables]}; exiting")
             else:
                 temp_val = val_dict[varval.variables]
     temp_negvar = set()
@@ -274,18 +274,18 @@ def check_bound_vars(actrvariables, elem, negative_impossible=True):
             try:
                 temp_result = actrvariables[var]
             except KeyError:
-                raise ACTRError("Object '%s' in the value '%s' is a variable that is not bound; this is illegal in ACT-R" % (var[1:], elem)) #is this correct? maybe in some special cases binding only in RHS should be allowed? If so this should be adjusted in productions.py
+                raise ACTRError(f"Object '{var[1:]}' in the value '{elem}' is a variable that is not bound; this is illegal in ACT-R") #is this correct? maybe in some special cases binding only in RHS should be allowed? If so this should be adjusted in productions.py
         elif x == "values" and getattr(varval, x):
             temp_result = getattr(varval, x)
         elif x == "negvalues" and getattr(varval, x):
             if negative_impossible:
-                raise ACTRError("It is not allowed to define negative values or negative variables on the right hand side of some ACT-R rules, notably, the ones that do not search environment or memory; '%s' is illegal in this case" % elem)
+                raise ACTRError(f"It is not allowed to define negative values or negative variables on the right hand side of some ACT-R rules, notably, the ones that do not search environment or memory; '{elem}' is illegal in this case")
             else:
                 for neg in getattr(varval, x):
                     neg_result.add(neg)
         elif x == "negvariables" and getattr(varval, x):
             if negative_impossible:
-                raise ACTRError("It is not allowed to define negative values or negative variables on the right hand side of some ACT-R rules, notably, the ones that do not search environment or memory; '%s' is illegal in this case" % elem)
+                raise ACTRError(f"It is not allowed to define negative values or negative variables on the right hand side of some ACT-R rules, notably, the ones that do not search environment or memory; '{elem}' is illegal in this case")
             else:
                 for neg in getattr(varval, x):
                     neg_var = neg
@@ -293,11 +293,11 @@ def check_bound_vars(actrvariables, elem, negative_impossible=True):
                     try:
                         neg_result.add(actrvariables[neg_var])
                     except KeyError:
-                        raise ACTRError("Object '%s' in the value '%s' is a variable that is not bound; this is illegal in ACT-R" % (var[1:], elem)) #is this correct? maybe in some special cases binding only in RHS should be allowed? If so this should be adjusted in productions.py
+                        raise ACTRError(f"Object '{var[1:]}' in the value '{elem}' is a variable that is not bound; this is illegal in ACT-R") #is this correct? maybe in some special cases binding only in RHS should be allowed? If so this should be adjusted in productions.py
         if result and temp_result in {VISIONGREATER, VISIONSMALLER} or result in {VISIONGREATER, VISIONSMALLER}:
             result = "".join(sorted([temp_result, result], reverse=True))
         elif result and temp_result != result:
-            raise ACTRError("It looks like in '%s', one slot would have to carry two values at the same time; this is illegal in ACT-R" % elem)
+            raise ACTRError(f"It looks like in '{elem}', one slot would have to carry two values at the same time; this is illegal in ACT-R")
         else:
             try:
                 result = temp_result
@@ -389,7 +389,7 @@ def match(dict2, slotvals, name1, name2):
                         val3 = chunkpart3.values
 
                     if val2 and val3 and val2 != val3:
-                        raise ACTRError("The values in rules '%s' and '%s' do not match, production compilation failed" % (name1, name2))
+                        raise ACTRError(f"The values in rules '{name1}' and '{name2}' do not match, production compilation failed")
             
                     temp_val = val2 or val3
 
@@ -709,4 +709,3 @@ def splitting_submodules(string): #currently not used, maybe eventually !!!not u
     variables = re.findall("(?<="+ ACTRVARIABLER+").*?(?=$)", string)
     retrievals = re.findall("(?<="+ ACTRRETRIEVER+").*?(?=$)", string)
     return {"variables": set(variables), "retrievals": set(retrievals)}
-

--- a/pyactr/vision.py
+++ b/pyactr/vision.py
@@ -98,7 +98,7 @@ class VisualLocation(buffers.Buffer):
         try:
             mod_attr_val = {x[0]: utilities.check_bound_vars(actrvariables, x[1], negative_impossible=False) for x in otherchunk.removeunused()}
         except utilities.ACTRError as arg:
-            raise utilities.ACTRError("The chunk '%s' is not defined correctly; %s" % (otherchunk, arg))
+            raise utilities.ACTRError(f"The chunk '{otherchunk}' is not defined correctly; {arg}")
         chunk_used_for_search = chunks.Chunk(utilities.VISUALLOCATION, **mod_attr_val)
             
         found = None
@@ -330,7 +330,7 @@ class Visual(buffers.Buffer):
         try:
             mod_attr_val = {x[0]: utilities.check_bound_vars(actrvariables, x[1]) for x in otherchunk.removeunused()}
         except ACTRError as arg:
-            raise ACTRError("Shifting towards the chunk '%s' is impossible; %s" % (otherchunk, arg))
+            raise ACTRError(f"Shifting towards the chunk '{otherchunk}' is impossible; {arg}")
 
         vis_delay = None
 


### PR DESCRIPTION
Also removes some extraneous parentheses around “raise”.

(Pylint C0209)